### PR TITLE
ゲストログイン機能を追加

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -3,6 +3,7 @@
 class Users::RegistrationsController < Devise::RegistrationsController
   # before_action :configure_sign_up_params, only: [:create]
   # before_action :configure_account_update_params, only: [:update]
+  before_action :ensure_normal_user, only: :destroy
 
   # GET /resource/sign_up
   # def new
@@ -29,6 +30,13 @@ class Users::RegistrationsController < Devise::RegistrationsController
     @user = current_user
     @user.delete
     flash[:notice] = t('flash.notices.delete')
+    redirect_to :root
+  end
+
+  def ensure_normal_user
+    return unless resource.email == 'guest@example.com'
+
+    flash[:alert] = t('flash.alerts.delete')
     redirect_to :root
   end
 

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -18,6 +18,13 @@ class Users::SessionsController < Devise::SessionsController
   #   super
   # end
 
+  def guest_sign_in
+    guest_user = User.guest
+    sign_in guest_user
+    flash[:notice] = t('flash.notices.sign_in')
+    redirect_to root_path
+  end
+
   # protected
 
   # If you have extra params to permit, append them to the sanitizer.

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,6 +3,7 @@ class UsersController < ApplicationController
 
   def show
     @user = current_user
+    @guest_user =  User.find_by(email: 'guest@example.com')
     @target_user = User.find(params[:id])
     @current_entry = Entry.where(user_id: @user.id)
     @another_entry = Entry.where(user_id: @target_user.id)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,4 +11,11 @@ class User < ApplicationRecord
   has_many :entries, dependent: :destroy
   has_many :messages, dependent: :destroy
   has_many :sightings, dependent: :destroy
+
+  def self.guest
+    find_or_create_by!(email: 'guest@example.com') do |user|
+      user.password = SecureRandom.urlsafe_base64
+      user.username = 'guest'
+    end
+  end
 end

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -68,6 +68,9 @@
           <nav class="nav">
             <ul>
               <li>
+                <%= button_to 'ゲストログイン', users_guest_sign_in_path, method: :post %>
+              </li>
+              <li>
                 <%= link_to new_user_session_path, class:'header-link' do %>
                   <%= image_tag 'login.png', class:'menu-logo' %>
                   <span class='nav-item'>ログイン</span>

--- a/app/views/users/show.erb
+++ b/app/views/users/show.erb
@@ -14,7 +14,21 @@
     <th>ユーザー名：</th>
     <td><%= @target_user.username %></td>
   </tr>
-  <% if @target_user.id == @user.id %>
+  <% if @target_user.id == @user.id && @guest_user == @user %>
+    <% provide(:title, "ゲスト の マイページ") %>
+    <tr>
+      <th>メールアドレス：</th>
+      <td><%= @user.email %></td>
+    </tr>
+    <tr>
+      <th>パスワード：</th>
+      <td>ゲストユーザーは変更できません。</td>
+    </tr>
+    <tr>
+      <th>設定：</th>
+      <td>ゲストユーザーは変更できません。</td>
+    </tr>
+  <% elsif @target_user.id == @user.id %>
     <% provide(:title, "#{@user.username} の マイページ") %>
     <tr>
       <th>メールアドレス：</th>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -206,6 +206,7 @@ ja:
       update: 更新しました。
       destroy: 投稿を削除しました。
       delete: ユーザーを削除しました。
+      sign_in: ゲストでログインしました
     alerts:
       update_fail: 更新に失敗しました。
       create_fail: 新規作成に失敗しました。

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -210,3 +210,4 @@ ja:
     alerts:
       update_fail: 更新に失敗しました。
       create_fail: 新規作成に失敗しました。
+      delete: ゲストユーザーは削除できません。

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
   }
   devise_scope :user do
     get '/users/sign_out' => 'devise/sessions#destroy'
+    post '/users/guest_sign_in', to: 'users/sessions#guest_sign_in'
   end
   resources :users, only: [:show, :edit, :update]
   resources :messages, only: [:create]

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -12,4 +12,11 @@ FactoryBot.define do
     password              {"654321"}
     password_confirmation {"654321"}
   end
+
+  factory :guest_user,class: User do
+    username              {"guest"}
+    email                 {"guest@example.com"}
+    password              {"111111"}
+    password_confirmation {"111111"}
+  end
 end

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 RSpec.describe 'Users' do
   let(:user) { create(:user) }
   let(:other_user) { create(:other_user) }
+  let(:guest_user) { create(:guest_user) }
 
   describe 'ユーザー新規登録について' do
     before do
@@ -258,6 +259,17 @@ RSpec.describe 'Users' do
 
       it 'ダイレクトメッセージの表示があること' do
         expect(page).to have_content '連絡をする'
+      end
+    end
+
+    context 'guest_userがサインインしている場合' do
+      before do
+        sign_in guest_user
+        visit user_path(guest_user)
+      end
+
+      it 'ゲストユーザーは変更できません。の表示があること' do
+        expect(page).to have_content 'ゲストユーザーは変更できません。'
       end
     end
   end


### PR DESCRIPTION
## 変更の概要
ゲストログイン機能の追加
* ヘッダーにリンクを追加
* マイページでの表示内容を変更

## 変更内容
* コントローラーにguest_sign_inアクションを追加
　特定のメールアドレス`guest@example.com`を設定
　パスワードはランダムに設定
* アカウントの編集・削除がされないよう設定
　また、編集先のリンクを非表示にした
