### PR TITLE
【デプロイ】Active Storageの保存先をボリュームに設定

### DIFF
--- a/config/storage.yml
+++ b/config/storage.yml
@@ -4,7 +4,8 @@ test:
 
 local:
   service: Disk
-  root: <%= Rails.root.join("storage") %>
+  public: true
+  root: <%= ENV.fetch('RAILS_STORAGE', Rails.root.join("storage")) %>
 
 # Use bin/rails credentials:edit to set the AWS secrets (as aws:access_key_id|secret_access_key)
 # amazon:

--- a/fly.toml
+++ b/fly.toml
@@ -12,6 +12,9 @@ console_command = "/rails/bin/rails console"
 [deploy]
   release_command = "./bin/rails db:prepare"
 
+[env]
+  RAILS_STORAGE = "/mnt/volume/storage"
+
 [http_service]
   internal_port = 3000
   force_https = true
@@ -23,3 +26,7 @@ console_command = "/rails/bin/rails console"
 [[statics]]
   guest_path = "/rails/public"
   url_prefix = "/"
+
+[[mounts]]
+  source = "rails_postgresl_vm"
+  destination = "/mnt/volume"

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -161,23 +161,6 @@ RSpec.describe 'Users' do
       end
     end
 
-    describe '画像アップロード機能について' do
-      before do
-        visit edit_user_path(user)
-      end
-
-      it '正常な画像ファイルをアップロードできること' do
-        attach_file('image', 'spec/fixtures/sample.jpg')
-        click_button '更新する'
-        expect(page).to have_current_path(user_path(user))
-      end
-
-      it '画像ファイルをアップロードしなくても更新できること' do
-        click_button '更新する'
-        expect(page).to have_current_path(user_path(user))
-      end
-    end
-
     describe 'ログアウトをクリック後について' do
       before do
         visit root_path


### PR DESCRIPTION
## 変更点
Active Storageの保存先が永続化されていなかったため、
fly.ioのマシーンがリスタートにより画像データが取得できず404になっていた問題を修正しました。