### PR TITLE
【UI/UX改善】詳細リンク修正、犬種表示、ヘッダー調整

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -442,6 +442,7 @@ h1 {
   background: #B7B7B7;
   box-sizing: border-box;
   border-right: 1px solid #545353;
+  max-width: 220px;
 }
 
 .header-logo {
@@ -489,6 +490,7 @@ h1 {
     width: 100%;
     height: 50px;
     border: 1px solid #545353;
+    max-width: none;
   }
 
   .header-logo {

--- a/app/views/ambles/index.erb
+++ b/app/views/ambles/index.erb
@@ -57,11 +57,11 @@
         </tr>
         <tr>
           <th>迷子の日時：</th>
-          <td><%= l a.date %>|<%= a.time %></td>
+          <td><%= l a.date %><%= a.time %></td>
         </tr>
         <tr>
           <th>迷子の場所：</th>
-          <td><%= a.prefecture %>|<%= a.municipalities %>|<%= a.area %></td>
+          <td><%= a.prefecture %><%= a.municipalities %><%= a.area %></td>
         </tr>
         <tr>
           <th>迷子の状況：</th>

--- a/app/views/ambles/list.erb
+++ b/app/views/ambles/list.erb
@@ -1,5 +1,6 @@
 <h2 class="title">ー 投稿一覧 ー</h2>
 <div class="index">
+<% if @amble.present? %>
   <% @amble.each do |a| %>
     <% provide(:title, "#{a.user.username} の 迷子犬一覧") %>
     <div class="amble-index">
@@ -39,4 +40,7 @@
       </table>
     </div>
   <% end %>
+<% else %>
+  <h2 class="post-nil"><i class="fa-solid fa-signs-post"></i>投稿はありません</h2>
+<% end %>
 </div>

--- a/app/views/ambles/list.erb
+++ b/app/views/ambles/list.erb
@@ -26,11 +26,11 @@
         </tr>
         <tr>
           <th>迷子の日時：</th>
-          <td><%= l a.date %>|<%= a.time %></td>
+          <td><%= l a.date %><%= a.time %></td>
         </tr>
         <tr>
           <th>迷子の場所：</th>
-          <td><%= a.prefecture %>|<%= a.municipalities %>|<%= a.area %></td>
+          <td><%= a.prefecture %><%= a.municipalities %><%= a.area %></td>
         </tr>
         <tr>
           <th>迷子の状況：</th>

--- a/app/views/ambles/myamble.erb
+++ b/app/views/ambles/myamble.erb
@@ -29,11 +29,11 @@
           </tr>
           <tr>
             <th>迷子の日時：</th>
-            <td><%= l a.date %>|<%= a.time %></td>
+            <td><%= l a.date %><%= a.time %></td>
           </tr>
           <tr>
             <th>迷子の場所：</th>
-            <td><%= a.prefecture %>|<%= a.municipalities %>|<%= a.area %></td>
+            <td><%= a.prefecture %><%= a.municipalities %><%= a.area %></td>
           </tr>
           <tr>
             <th>迷子の状況：</th>

--- a/app/views/ambles/myamble.erb
+++ b/app/views/ambles/myamble.erb
@@ -20,9 +20,6 @@
           <%= button_to amble_path(a), method: :delete, data: { turbo_confirm: "本当に削除しますか？" } do %>
             <i class="fa-solid fa-trash">投稿を削除</i>
           <% end %>
-          <%= button_to amble_path(a), method: :delete, data: { turbo_confirm: "個人情報保護のため削除します。" } do %>
-            <i class="fa-solid fa-circle-check">解決しました</i>
-          <% end %>
         </div>
 
         <table class="amble-index-table">

--- a/app/views/ambles/show.erb
+++ b/app/views/ambles/show.erb
@@ -29,7 +29,7 @@
           <i class="fa-solid fa-trash">投稿を削除</i>
         <% end %>
       <% else %>
-        <%= link_to "#{a.user.username}様", user_path(a) %></br>
+        <%= link_to "#{a.user.username}様", user_path(a.user.id) %></br>
         <% if @is_room == true %>
           <%= link_to room_path(@room_id), class:'' do %>
             <i class="fa-solid fa-envelope-open"></i>連絡をする

--- a/app/views/protects/index.erb
+++ b/app/views/protects/index.erb
@@ -46,11 +46,11 @@
         </tr>
         <tr>
           <th>保護日時：</th>
-          <td><%= l protect.date %>|<%= protect.time %></td>
+          <td><%= l protect.date %><%= protect.time %></td>
         </tr>
         <tr>
           <th>保護場所：</th>
-          <td><%= protect.prefecture %>|<%= protect.municipalities %>|<%= protect.area %></td>
+          <td><%= protect.prefecture %><%= protect.municipalities %><%= protect.area %></td>
         </tr>
         <tr>
           <th>保護状況：</th>

--- a/app/views/protects/index.erb
+++ b/app/views/protects/index.erb
@@ -41,8 +41,8 @@
 
       <table class="amble-index-table">
         <tr>
-          <th>名前：</th>
-          <td><%= protect.name %></td>
+          <th>犬種：</th>
+          <td><%= protect.breed %></td>
         </tr>
         <tr>
           <th>保護日時：</th>

--- a/app/views/protects/list.erb
+++ b/app/views/protects/list.erb
@@ -1,5 +1,6 @@
 <h2 class="title">ー 自分の投稿一覧 ー</h2>
 <div class="index">
+<% if @protect.present? %>
   <% @protect.each do |p| %>
     <% provide(:title, "#{p.user.username} の 保護犬一覧") %>
     <div class="amble-index">
@@ -39,4 +40,7 @@
       </table>
     </div>
   <% end %>
+<% else %>
+  <h2 class="post-nil"><i class="fa-solid fa-signs-post"></i>投稿はありません</h2>
+<% end %>
 </div>

--- a/app/views/protects/list.erb
+++ b/app/views/protects/list.erb
@@ -26,11 +26,11 @@
         </tr>
         <tr>
           <th>保護日時：</th>
-          <td><%= l p.date %>|<%= p.time %></td>
+          <td><%= l p.date %><%= p.time %></td>
         </tr>
         <tr>
           <th>保護場所：</th>
-          <td><%= p.prefecture %>|<%= p.municipalities %>|<%= p.area %></td>
+          <td><%= p.prefecture %><%= p.municipalities %><%= p.area %></td>
         </tr>
         <tr>
           <th>保護状況：</th>

--- a/app/views/protects/myprotect.erb
+++ b/app/views/protects/myprotect.erb
@@ -20,9 +20,6 @@
           <%= button_to protect_path(p), method: :delete, data: { turbo_confirm: "本当に削除しますか？" } do %>
             <i class="fa-solid fa-trash">投稿を削除</i>
           <% end %>
-          <%= button_to protect_path(p), method: :delete, data: { turbo_confirm: "個人情報保護のため削除します。" } do %>
-            <i class="fa-solid fa-circle-check">解決しました</i>
-          <% end %>
         </div>
 
         <table class="amble-index-table">

--- a/app/views/protects/myprotect.erb
+++ b/app/views/protects/myprotect.erb
@@ -29,11 +29,11 @@
           </tr>
           <tr>
             <th>保護日時：</th>
-            <td><%= l p.date %>|<%= p.time %></td>
+            <td><%= l p.date %><%= p.time %></td>
           </tr>
           <tr>
             <th>保護場所：</th>
-            <td><%= p.prefecture %>|<%= p.municipalities %>|<%= p.area %></td>
+            <td><%= p.prefecture %><%= p.municipalities %><%= p.area %></td>
           </tr>
           <tr>
             <th>保護状況：</th>

--- a/app/views/protects/show.erb
+++ b/app/views/protects/show.erb
@@ -33,7 +33,7 @@
           <i class="fa-solid fa-trash">投稿を削除</i>
         <% end %>
       <% else %>
-        <%= link_to "#{p.user.username}様", user_path(p) %></br>
+        <%= link_to "#{p.user.username}様", user_path(p.user.id) %></br>
         <% if @is_room == true %>
           <%= link_to room_path(@room_id), class:'' do %>
             <i class="fa-solid fa-envelope-open"></i>連絡をする

--- a/app/views/protects/transferred.erb
+++ b/app/views/protects/transferred.erb
@@ -41,11 +41,11 @@
 
       <table class="amble-index-table">
         <tr>
-          <th>迷子の日時：</th>
+          <th>保護の日時：</th>
           <td><%= l a.date %><%= a.time %></td>
         </tr>
         <tr>
-          <th>迷子の場所：</th>
+          <th>保護の場所：</th>
           <td><%= a.prefecture %><%= a.municipalities %><%= a.area %></td>
         </tr>
         <tr>

--- a/app/views/protects/transferred.erb
+++ b/app/views/protects/transferred.erb
@@ -42,11 +42,11 @@
       <table class="amble-index-table">
         <tr>
           <th>迷子の日時：</th>
-          <td><%= l a.date %>|<%= a.time %></td>
+          <td><%= l a.date %><%= a.time %></td>
         </tr>
         <tr>
           <th>迷子の場所：</th>
-          <td><%= a.prefecture %>|<%= a.municipalities %>|<%= a.area %></td>
+          <td><%= a.prefecture %><%= a.municipalities %><%= a.area %></td>
         </tr>
         <tr>
           <th>預けている</br>場所・予定</th>

--- a/app/views/sightings/list.erb
+++ b/app/views/sightings/list.erb
@@ -1,34 +1,38 @@
-<% @sighting.each do |sighting|%>
-  <% provide(:title, "#{sighting.user.username} の 目撃情報一覧") %>
-  <div id="easyModal<%= sighting.id %>" class="modal">
-    <div class="modal-content">
-      <div class="modal-header">
-        <h2>目撃情報の詳細</h2>
-        <span class="modalClose">×</span>
-      </div>
-      <div class="modal-body">
-        <div class="modal-image">
-          <% if @user.image.attached? %>
-            <%= image_tag @user.image, :size => '200x200' %>
-          <% else %>
-            <%= image_tag("default_user.png", :size => "200x200") %>
-          <% end %>
+<% if @sighting.present? %>
+  <% @sighting.each do |sighting|%>
+    <% provide(:title, "#{sighting.user.username} の 目撃情報一覧") %>
+    <div id="easyModal<%= sighting.id %>" class="modal">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h2>目撃情報の詳細</h2>
+          <span class="modalClose">×</span>
         </div>
-        <h3>日時：</h3>
-        <p><%= l sighting.date %></p>
-        <p><%= sighting.time %></p>
-        <h3>場所：</h3>
-        <p><%= sighting.area %></p>
-        <h3>状況：</h3>
-        <p><%= sighting.situation %></p>
-        <p>
-          <%= link_to user_path(sighting.user_id) do %>
-            <i class="fa-solid fa-envelope"></i>連絡をする
-          <% end %>
-        </p>
+        <div class="modal-body">
+          <div class="modal-image">
+            <% if @user.image.attached? %>
+              <%= image_tag @user.image, :size => '200x200' %>
+            <% else %>
+              <%= image_tag("default_user.png", :size => "200x200") %>
+            <% end %>
+          </div>
+          <h3>日時：</h3>
+          <p><%= l sighting.date %></p>
+          <p><%= sighting.time %></p>
+          <h3>場所：</h3>
+          <p><%= sighting.area %></p>
+          <h3>状況：</h3>
+          <p><%= sighting.situation %></p>
+          <p>
+            <%= link_to user_path(sighting.user.id) do %>
+              <i class="fa-solid fa-envelope"></i>連絡をする
+            <% end %>
+          </p>
+        </div>
       </div>
     </div>
-  </div>
+  <% end %>
+<% else %>
+  <h2 class="sightings-nil"><i class="fa-solid fa-signs-post"></i>投稿はありません</h2>
 <% end %>
 
 <div class="sighting-map-index">

--- a/app/views/sightings/show.erb
+++ b/app/views/sightings/show.erb
@@ -29,7 +29,7 @@
           <i class="fa-solid fa-trash">投稿を削除</i>
         <% end %>
       <% else %>
-        <%= link_to "#{@sighting.user.username}", user_path(@sighting) %>様</br>
+        <%= link_to "#{@sighting.user.username}様", user_path(@sighting.user.id) %></br>
         <% if @is_room == true %>
           <%= link_to room_path(@room_id), class:'' do %>
             <i class="fa-solid fa-envelope-open"></i>連絡をする

--- a/spec/system/protects_spec.rb
+++ b/spec/system/protects_spec.rb
@@ -173,9 +173,9 @@ RSpec.describe 'Protects' do
       visit protects_path(protect)
     end
 
-    it '名前が正常に表示されること' do
+    it '犬種が正常に表示されること' do
       within('.index') do
-        expect(page).to have_content protect.name
+        expect(page).to have_content protect.breed
       end
     end
 


### PR DESCRIPTION
## 変更の概要
### 修正点
リンクのエラーを修正しました。
* 自分の投稿からの`解決しました`を削除
* 投稿詳細ページからマイページへ飛べない問題を修正

保護犬、一覧ページ内の文言を変更しました。
* 保護犬の一覧ページで、名前の代わりに犬種を表示するように変更しました。
* 一時お預かりの一覧ページで、「迷子」という文言を「保護」に変更しました。

他ユーザーの投稿が0件の場合、投稿一覧ページに「まだ投稿がありません」というメッセージを表示するように変更しました。
ヘッダーにmax-widthを追加しました。