### PR TITLE
【修正】目撃情報の状況入力欄の属性名

### DIFF
--- a/app/views/sightings/new.erb
+++ b/app/views/sightings/new.erb
@@ -55,7 +55,7 @@
 
       <div class="board-item">
         <span class="Form-Item-Label-Any">任意</span><i class="fa-solid fa-paw"></i>
-        <%= f.text_area :time, class: "board-item-input", placeholder: "特徴や状況", value: @sighting.situation %>
+        <%= f.text_area :situation, class: "board-item-input", placeholder: "特徴や状況", value: @sighting.situation %>
         <div class="message">
           <a href="#">
             <i class="fa-solid fa-circle-exclamation"></i>


### PR DESCRIPTION
* 状況入力欄の属性名を `:time` から `:situation` に変更
* 誤った属性名を使用していたため、修正

