### PR TITLE
【機能改善】バリデーションの修正

### DIFF
--- a/app/models/amble.rb
+++ b/app/models/amble.rb
@@ -4,8 +4,8 @@ class Amble < ApplicationRecord
 
   validates :name, :size, :gender, :date, :municipalities, presence: true
   validates :features, :situation, length: { maximum: 50 }
+  validates :prefecture, exclusion: { in: ['都道府県'] }
   validate :date_before_start
-  validate :prefecture_cannot_be_zero
 
   def date_before_start
     if date.nil?
@@ -14,9 +14,5 @@ class Amble < ApplicationRecord
       errors.add(:date, "は今日を含む前の日付を登録してください。") unless
       date <= Date.current
     end
-  end
-
-  def prefecture_cannot_be_zero
-    errors.add(:prefecture, "選択してください") if prefecture == 0
   end
 end

--- a/app/models/protect.rb
+++ b/app/models/protect.rb
@@ -4,8 +4,7 @@ class Protect < ApplicationRecord
 
   validates :date, :size, :gender, :situation, :municipalities, presence: true
   validates :features, :situation, length: { maximum: 50 }
-  validate :prefecture_cannot_be_zero
-
+  validates :prefecture, exclusion: { in: ['都道府県'] }
   validate :date_before_start
 
   def date_before_start
@@ -15,9 +14,5 @@ class Protect < ApplicationRecord
       errors.add(:date, "は今日を含む前の日付を登録してください。") unless
       date <= Date.current
     end
-  end
-
-  def prefecture_cannot_be_zero
-    errors.add(:prefecture, "選択してください") if prefecture == 0
   end
 end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -16,6 +16,7 @@ ja:
         size: "犬の大きさ"
         gender: "犬の性別"
         features: "犬の特徴"
+        prefecture: "都道府県"
         municipalities: "市区町村"
         situation: "保護した状況"
       sighting:
@@ -112,7 +113,7 @@ ja:
       empty: を入力してください
       equal_to: は%{count}にしてください
       even: は偶数にしてください
-      exclusion: は予約されています
+      exclusion: を選択してください
       greater_than: マーカーを立ててください
       greater_than_or_equal_to: は%{count}以上の値にしてください
       in: は%{count}の範囲に含めてください


### PR DESCRIPTION
## 変更の概要
迷子犬について投稿時に、都道府県が選択されていなくても登録できていた問題を修正。

### 変更点
`exclusion`を使って`都道府県`を選択できないようにした。