### PR TITLE
【UI/UX改善】UIの修正、目撃情報：自分の投稿一覧画面にリスト表示を追加

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -149,16 +149,10 @@ i::before {
 
 h1 {
   position: absolute;
-  top: 15%;
-  left: 80%;
-  transform: translate(-50%, -50%);
-  width: 255px;
-  margin-left: 20px;
-  padding-top: 3px;
-  padding-left: 20px;
+  top: 220px;
+  left: 76%;
   font-size: 25px;
 }
-
 
 .top-new {
   position: absolute;
@@ -197,20 +191,28 @@ h1 {
   margin-left: 150px;
 }
 
+@media screen and (max-width:1280px) {
+  h1 {
+    top: 110px;
+    left: 73%;
+  }
+}
+
 @media screen and (max-width:1024px) {
   .top-logo {
+    top: 370px;
     left: 50%;
   }
 
   .top-new {
-    top: 130%;
+    top: 940px;
     left: 50%;
     padding-bottom: 30px;
   }
 
   h1 {
-    top: 720px;
-    left: 48%;
+    top: 660px;
+    left: 38%;
   }
 
   .sightings-nil {
@@ -226,12 +228,18 @@ h1 {
 
 @media screen and (max-width:600px) {
   .top-logo {
+    top: 280px;
     width: 380px;
   }
 
   h1 {
-    top: 600px;
-    left: 46%;
+    top: 480px;
+    left: 25%;
+  }
+
+  .top-new {
+    top: 750px;
+    left: 52%;
   }
 
   .sightings-nil {
@@ -351,7 +359,8 @@ h1 {
   }
 
   .information-link {
-    left: 50%;
+    top: 600px;
+    left: 51%;
   }
 
   .info-amble-link {
@@ -391,6 +400,8 @@ h1 {
 @media screen and (max-width:600px) {
   .information-link {
     width: 300px;
+    top: 430px;
+    left: 55%;
   }
 
   .info-amble-link {

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1312,7 +1312,7 @@ caption {
 
 .board-situation {
   position: relative;
-  top: -40px;
+  top: -37px;
   left: 80px;
   width: 200px;
   height: 230px;
@@ -1329,12 +1329,12 @@ caption {
 
 .board-situation li:nth-child(4) {
   position: absolute;
-  top: 120px;
+  top: 111px;
 }
 
 .board-features {
   position: relative;
-  top: 25px;
+  top: 26px;
   left: 100px;
   width: 450px;
   height: 130px;

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -957,11 +957,8 @@ div.form_area .col {
   font-size: 18px;
   font-weight: bold;
   padding: 0px 5px;
-  margin: 10px;
   border-radius: 10px;
-  position: relative;
-  top: -60px;
-  left: 60%;
+  margin-left: 450px;
 }
 
 .back {
@@ -1148,7 +1145,7 @@ div.form_area .col {
     margin-left: auto;
     padding: 0 20px;
     width: 90%;
-    height: 600px;
+    height: 530px;
   }
 
   .board-Label {
@@ -1160,12 +1157,20 @@ div.form_area .col {
     font-size: 10px;
   }
 
+  .btndesign {
+    margin-top: 10px;
+    margin-left: 240px;
+    padding: 5px 10px;
+    font-size: 13px;
+  }
+
   .protect-back {
     font-size: 13px;
   }
 
   .second-back {
-    top: 42px;
+    top: -1px;
+    left: -20px;
     font-size: 13px;
   }
 
@@ -1215,7 +1220,7 @@ div.form_area .col {
 
 @media screen and (max-width:600px) {
   .back {
-    top: 20px;
+    top: 0px;
   }
 }
 

--- a/app/controllers/sightings_controller.rb
+++ b/app/controllers/sightings_controller.rb
@@ -88,12 +88,12 @@ class SightingsController < ApplicationController
 
   def mysighting
     @user = current_user
-    @sighting = Sighting.where(user_id: current_user.id)
+    @sighting = Sighting.where(user_id: current_user.id).page(params[:page]).per(10)
   end
 
   def list
     @user = current_user
-    @sighting = Sighting.where(user_id: params[:id])
+    @sighting = Sighting.where(user_id: params[:id]).page(params[:page]).per(10)
   end
 
   def topic

--- a/app/views/ambles/edit.erb
+++ b/app/views/ambles/edit.erb
@@ -121,8 +121,8 @@
             <%= f.select :chip, [['なし',0],['付いてます',1]], { include_blank: true, selected: 0 }, class: "board-item-select" %>
           </div>
         </div>
+        <button type="button" class="btndesign" id="form_next">次へ</button>
       </div>
-			<button type="button" class="btndesign" id="form_next">次へ</button>
     </section>
 
 		<section class="personal col hidden">

--- a/app/views/ambles/myamble.erb
+++ b/app/views/ambles/myamble.erb
@@ -17,7 +17,7 @@
           <%= l a.created_at %></br>
           <%= link_to "【詳細を見る】", amble_path(a) %>
           <%= link_to "【編集する】", edit_amble_path(a) %>
-          <%= button_to amble_path(a), method: :delete, data: { turbo_confirm: "本当に削除しますか？" } do %>
+          <%= button_to amble_path(a), class: "board-btn", method: :delete, data: { turbo_confirm: "本当に削除しますか？" } do %>
             <i class="fa-solid fa-trash">投稿を削除</i>
           <% end %>
           <%= button_tag id: "delete-btn", class: "board-btn", data: { turbo: false } do %>

--- a/app/views/ambles/new.erb
+++ b/app/views/ambles/new.erb
@@ -121,8 +121,8 @@
             <%= f.select :chip, [['なし',0],['付いてます',1]], { include_blank: true, selected: 0 }, class: "board-item-select" %>
           </div>
         </div>
+        <button type="button" class="btndesign" id="form_next">次へ</button>
       </div>
-			<button type="button" class="btndesign" id="form_next">次へ</button>
     </section>
 
 		<section class="personal col hidden">

--- a/app/views/ambles/show.erb
+++ b/app/views/ambles/show.erb
@@ -45,8 +45,9 @@
         </div>
       <% else %>
         <%= link_to "#{a.user.username}様", user_path(a.user.id) %></br>
+        <i class="fa-solid fa-user"><%= link_to "プロフィールを見る", user_path(a.user.id) %></i>
         <% if @is_room == true %>
-          <%= link_to room_path(@room_id), class:'' do %>
+          <%= link_to room_path(@room_id), class:'board-btn' do %>
             <i class="fa-solid fa-envelope-open"></i>連絡をする
           <% end %>
         <% else %>
@@ -54,7 +55,7 @@
             <%= fields_for @entry do |e| %>
               <%= e.hidden_field :user_id, value: @amble_user.user.id %>
             <% end %>
-            <button type="submit" class=""><i class="fa-regular fa-envelope"></i>連絡をする</button>
+            <button type="submit" class="board-btn"><i class="fa-regular fa-envelope"></i>連絡をする</button>
           <% end %>
         <% end %>
       <% end %>

--- a/app/views/protects/edit.erb
+++ b/app/views/protects/edit.erb
@@ -121,8 +121,8 @@
             <%= f.select :chip, [['なし',0],['付いてます',1]], { include_blank: true, selected: 0 }, class: "board-item-select" %>
           </div>
         </div>
+        <button type="button" class="btndesign" id="first-next">次へ</button>
       </div>
-      <button type="button" class="btndesign" id="first-next">次へ</button>
     </section>
 
     <section class="personal col hidden">
@@ -227,8 +227,8 @@
           </div>
         </div>
         <p class="protect-back" id="first-back"><i class="fa-solid fa-reply"></i>戻る</p>
+        <button type="button" class="btndesign" id="second-next">次へ</button>
       </div>
-      <button type="button" class="btndesign" id="second-next">次へ</button>
     </section>
 
     <section class="personal col hidden">

--- a/app/views/protects/myprotect.erb
+++ b/app/views/protects/myprotect.erb
@@ -17,7 +17,7 @@
           <%= l p.created_at %></br>
           <%= link_to "【詳細を見る】", protect_path(p) %>
           <%= link_to "【編集する】", edit_protect_path(p) %>
-          <%= button_to protect_path(p), method: :delete, data: { turbo_confirm: "本当に削除しますか？" } do %>
+          <%= button_to protect_path(p), class: "board-btn", method: :delete, data: { turbo_confirm: "本当に削除しますか？" } do %>
             <i class="fa-solid fa-trash">投稿を削除</i>
           <% end %>
           <%= button_tag id: "delete-btn", class: "board-btn", data: { turbo: false } do %>

--- a/app/views/protects/new.erb
+++ b/app/views/protects/new.erb
@@ -121,8 +121,8 @@
             <%= f.select :chip, [['なし',0],['付いてます',1]], { include_blank: true, selected: 0 }, class: "board-item-select" %>
           </div>
         </div>
+        <button type="button" class="btndesign" id="first-next">次へ</button>
       </div>
-      <button type="button" class="btndesign" id="first-next">次へ</button>
     </section>
 
     <section class="personal col hidden">
@@ -227,8 +227,8 @@
           </div>
         </div>
         <p class="protect-back" id="first-back"><i class="fa-solid fa-reply"></i>戻る</p>
+        <button type="button" class="btndesign" id="second-next">次へ</button>
       </div>
-      <button type="button" class="btndesign" id="second-next">次へ</button>
     </section>
 
     <section class="personal col hidden">

--- a/app/views/protects/show.erb
+++ b/app/views/protects/show.erb
@@ -49,8 +49,9 @@
         </div>
       <% else %>
         <%= link_to "#{p.user.username}様", user_path(p.user.id) %></br>
+        <i class="fa-solid fa-user"><%= link_to "プロフィールを見る", user_path(p.user.id) %></i>
         <% if @is_room == true %>
-          <%= link_to room_path(@room_id), class:'' do %>
+          <%= link_to room_path(@room_id), class:'board-btn' do %>
             <i class="fa-solid fa-envelope-open"></i>連絡をする
           <% end %>
         <% else %>
@@ -58,7 +59,7 @@
             <%= fields_for @entry do |e| %>
               <%= e.hidden_field :user_id, value: @protect_user.user.id %>
             <% end %>
-            <button type="submit" class=""><i class="fa-regular fa-envelope"></i>連絡をする</button>
+            <button type="submit" class="board-btn"><i class="fa-regular fa-envelope"></i>連絡をする</button>
           <% end %>
         <% end %>
       <% end %>

--- a/app/views/sightings/list.erb
+++ b/app/views/sightings/list.erb
@@ -40,6 +40,35 @@
   <div id='map'></div>
 </div>
 
+<h2 class="total">合計：<%= @sighting.count %>件</h2>
+
+<div class="sighting-index">
+  <% @sighting.each do |sighting| %>
+    <div class="c-card c-card--row">
+      <%= link_to sighting_path(sighting) do %>
+        <div class="c-card__contents">
+          <h2 class="c-card__title"><%= l sighting.date %><%= sighting.time %></h2>
+          <p class="c-card__text">
+            場所：<%= sighting.area %></br>
+            状況：<%= sighting.situation %></br>
+          </p>
+          <div class="c-card__thumbnail">
+            <% if sighting.image.attached? %>
+              <%= image_tag sighting.image, :size => '100x100' %>
+            <% else %>
+              <%= image_tag("default_user.png", :size => "100x100") %>
+            <% end %>
+          </div>
+          <ul class="c-card__info">
+          <li class="c-card__info-item">投稿日時：<%= sighting.created_at.strftime('%Y/%m/%d %H:%M') %></li>
+          </ul>
+        </div>
+      <% end %>
+    </div>
+  <% end %>
+  <%= paginate @sighting %>
+</div>
+
 <!-- js部分 -->
 <script>
   function modalOpenById(id) {

--- a/app/views/sightings/mysighting.erb
+++ b/app/views/sightings/mysighting.erb
@@ -41,6 +41,35 @@
   <div id='map'></div>
 </div>
 
+<h2 class="total">合計：<%= @sighting.count %>件</h2>
+
+<div class="sighting-index">
+  <% @sighting.each do |sighting| %>
+    <div class="c-card c-card--row">
+      <%= link_to sighting_path(sighting) do %>
+        <div class="c-card__contents">
+          <h2 class="c-card__title"><%= l sighting.date %><%= sighting.time %></h2>
+          <p class="c-card__text">
+            場所：<%= sighting.area %></br>
+            状況：<%= sighting.situation %></br>
+          </p>
+          <div class="c-card__thumbnail">
+            <% if sighting.image.attached? %>
+              <%= image_tag sighting.image, :size => '100x100' %>
+            <% else %>
+              <%= image_tag("default_user.png", :size => "100x100") %>
+            <% end %>
+          </div>
+          <ul class="c-card__info">
+          <li class="c-card__info-item">投稿日時：<%= sighting.created_at.strftime('%Y/%m/%d %H:%M') %></li>
+          </ul>
+        </div>
+      <% end %>
+    </div>
+  <% end %>
+  <%= paginate @sighting %>
+</div>
+
 <!-- js部分 -->
 <script>
   function modalOpenById(id) {


### PR DESCRIPTION
### 変更の概要

* 目撃情報の自分の投稿一覧画面にリスト表示を追加
    * 合計件数を表示
    * リスト表示では、投稿日時、場所、犬種、写真などを表示

* トップページのレイアウト崩れを修正
    * 特定のブラウザで、`新着目撃情報`の表示が崩れていた

* 投稿画面の「次へ」ボタンの崩れを修正
    * ボタンの位置を調整

* 投稿詳細画面のレイアウト崩れを修正
    * 画像の表示が崩れていた

* 削除ボタンに「board-btn」classを追加
    * デザインを統一